### PR TITLE
merge oddsratio 0.3

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,5 +3,7 @@
 ^.travis\..yml$
 README.Rmd
 README.md
+README.knit.md
+README.utf8.md
 .travis.yml
 ^cran-comments\.md$

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .Ruserdata
 oddsratio.Rproj
 inst/doc
+README.knit.md
+README.utf8.md

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,3 +3,4 @@
 export(calc.oddsratio.gam)
 export(calc.oddsratio.glm)
 importFrom(stats,coefficients)
+importFrom(stats,confint)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # oddsratio 0.3 
 
-* Add confident interval calculation (`calc.oddsratio.glm`)
+* Add confident interval calculation (`calc.oddsratio.glm`, `calc.oddsratio.gam`)
+* For GLM models CI level can be specified manually
+* Print CI warning if model is of type `glmmPQL`
 
 # oddsratio 0.2 (Oct 12 2016)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# oddsratio 0.3 
+
+* Add confident interval calculation (`calc.oddsratio.glm`)
+
 # oddsratio 0.2 (Oct 12 2016)
 
 * Remove param `quietly`

--- a/R/odds.ratio.glm.R
+++ b/R/odds.ratio.glm.R
@@ -2,6 +2,7 @@
 #' @title Calculate Odds Ratio of Generalized Linear (Mixed) Models
 #' 
 #' @importFrom stats coefficients
+#' @importFrom stats confint
 #' 
 #' @description This function calculates odds ratio(s) for specific 
 #'     increment steps of GLMs. 
@@ -9,11 +10,19 @@
 #' @param data The data used for model fitting.
 #' @param model A fitted GLM(M).
 #' @param incr List. Increment values of each predictor.
+#' @param CI numeric. Which confident interval to calculate. 
+#' Must be between 0 and 1. Default to 0.95
 #' 
-#' @return A data frame with three columns:
+#' @return A data frame with five columns:
 #' \item{predictor}{Predictor name(s)}
 #' \item{oddsratio}{Calculated odds ratio(s)}
+#' \item{CI.low}{Lower confident interval of odds ratio}
+#' \item{CI.high}{Higher confident interval of odds ratio}
 #' \item{increment}{Increment of the predictor(s)}
+#' 
+#' @details \code{CI.low} and {CI.high} are only calculted for GLM models because 
+#' \code{\link[MASS]{glmmPQL}} does not return confident intervals due to its penalizing
+#' behaviour. 
 #' 
 #' @examples 
 #' ## Example with stats::glm()
@@ -41,7 +50,7 @@
 #' @seealso \code{\link[oddsratio]{calc.oddsratio.gam}}
 #' 
 #' @export
-calc.oddsratio.glm <- function(data, model, incr) {
+calc.oddsratio.glm <- function(data, model, incr, CI = 0.95) {
   
   if (class(model)[1] == "glm") {
     # get pred names and coefficients without intercept
@@ -53,20 +62,35 @@ calc.oddsratio.glm <- function(data, model, incr) {
     # get pred names and coefficients without intercept
     preds <- names(model$coefficients$fixed)[2:length(model$coefficients$fixed)]
     coef <- model$coefficients$fixed[2:length(model$coefficients$fixed)]
+    
+    # CI not possible for glmmPQL models
+    CI <- NULL
   }
   
   increments <- list()
   odds.ratios <- list()
+  CI.low <- list()
+  CI.high <- list()
   for (i in preds) {
+    
+    # CI calculation
+    if (class(model)[1] == "glm") {
+      CI.list <- as.data.frame(suppressMessages(confint(model, level = CI))) [-1, ] 
+    }
+    
     # check if predictor is numeric or integer
     if (is.numeric(data[[i]]) | is.integer(data[[i]])) {
       odds.ratios[[i]] <- round(exp(as.numeric(coef[[i]]) * as.numeric(incr[[i]])), 3)
+      CI.low[[i]] <- round(exp(CI.list[i, 1] * as.numeric(incr[[i]])), 3)
+      CI.high[[i]] <- round(exp(CI.list[i, 2] * as.numeric(incr[[i]])), 3)
       increments[[i]] <- as.numeric(incr[[i]])
       or <- odds.ratios[[i]]
     }
     # if pred is factor -> perform direct conversion to odds ratio
     else {
       odds.ratios[[i]] <- round(exp(as.numeric(coef[[i]])), 3)
+      CI.low[[i]] <- round(exp(CI.list[i, 1]), 3)
+      CI.high[[i]] <- round(exp(CI.list[i, 2]), 3)
       increments[[i]] <- "Indicator variable"
       or <- odds.ratios[[i]]
     }
@@ -75,8 +99,17 @@ calc.oddsratio.glm <- function(data, model, incr) {
   # create data frame to return
   result <- data.frame(predictor = as.character(names(odds.ratios)),
                        oddsratio = unlist(odds.ratios, use.names = FALSE),
+                       CI.low = unlist(CI.low, use.names = FALSE),
+                       CI.high = unlist(CI.high, use.names = FALSE),
                        increment = as.character(unlist(increments, 
                                                        use.names = FALSE)),
                        stringsAsFactors = FALSE)
+  
+  # set CI column names
+  if (class(model)[1] == "glm") {
+    colnames(result)[3] <- paste0("CI.low (", names(CI.list) [1], ")")
+    colnames(result)[4] <- paste0("CI.high (", names(CI.list) [2], ")")
+  }
+  
   return(result)
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -8,6 +8,7 @@ knitr::opts_chunk$set(echo = TRUE)
 
 [![Build Status](https://travis-ci.org/pat-s/oddsratio.svg?branch=master)](https://travis-ci.org/pat-s/oddsratio)
 [![CRAN_Status_Badge](http://www.r-pkg.org/badges/version/oddsratio)](http://cran.r-project.org/package=oddsratio)
+[![Rdoc](http://www.rdocumentation.org/badges/version/oddsratio)](http://www.rdocumentation.org/packages/oddsratio)
 [![Downloads](http://cranlogs.r-pkg.org/badges/oddsratio?color=brightgreen)](http://www.r-pkg.org/pkg/oddsratio)
 
 # oddsratio

--- a/README.Rmd
+++ b/README.Rmd
@@ -93,6 +93,5 @@ vignette.
 
 ## To Do
 
-- Add calculation of odds ratio confidence intervals
-- Implement plotting function of calculated odds ratio in GLM/GAM function?
+- Implement some kind of plotting of calculated odds ratios within the smooth functions?
 - Add references for odds ratio calculation?

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ fit.glm <- glm(admit ~ gre + gpa + rank, data = dat, family = "binomial")
 calc.oddsratio.glm(data = dat, model = fit.glm, incr = list(gre = 380, gpa = 5))
 ```
 
-    ##   predictor oddsratio          increment
-    ## 1       gre     2.364                380
-    ## 2       gpa    55.712                  5
-    ## 3     rank2     0.509 Indicator variable
-    ## 4     rank3     0.262 Indicator variable
-    ## 5     rank4     0.212 Indicator variable
+    ##   predictor oddsratio CI.low (2.5 %) CI.high (97.5 %)          increment
+    ## 1       gre     2.364          1.054            5.396                380
+    ## 2       gpa    55.712          2.229         1511.282                  5
+    ## 3     rank2     0.509          0.272            0.945 Indicator variable
+    ## 4     rank3     0.262          0.132            0.512 Indicator variable
+    ## 5     rank4     0.212          0.091            0.471 Indicator variable
 
 ### GAM
 
@@ -50,12 +50,18 @@ calc.oddsratio.gam(data = dat, model = fit.gam, pred = "x2",
                    percentage = 20, slice = TRUE)
 ```
 
-    ##   predictor value1 value2 perc1 perc2    oddsratio
-    ## 1        x2  0.001  0.200     0    20 2.510768e+03
-    ## 2        x2  0.200  0.400    20    40 2.870699e-02
-    ## 3        x2  0.400  0.599    40    60 5.761210e-01
-    ## 4        x2  0.599  0.799    60    80 6.032289e-02
-    ## 5        x2  0.799  0.998    80   100 4.063187e-01
+    ##   predictor value1 value2 perc1 perc2    oddsratio CI.low (2.5%)
+    ## 1        x2  0.001  0.200     0    20 2.510768e+03  1.091683e+03
+    ## 2        x2  0.200  0.400    20    40 2.870699e-02  2.621879e-02
+    ## 3        x2  0.400  0.599    40    60 5.761210e-01  5.556941e-01
+    ## 4        x2  0.599  0.799    60    80 6.032289e-02  5.789875e-02
+    ## 5        x2  0.799  0.998    80   100 4.063187e-01  7.469151e-01
+    ##   CI.high (97.5%)
+    ## 1    5.774533e+03
+    ## 2    3.143133e-02
+    ## 3    5.972988e-01
+    ## 4    6.284853e-02
+    ## 5    2.210357e-01
 
 If you want to compute a single odds ratio for specific values, simply set param `slice = FALSE`:
 
@@ -64,8 +70,8 @@ calc.oddsratio.gam(data = dat, model = fit.gam,
                    pred = "x2", values = c(0.099, 0.198))
 ```
 
-    ##   predictor value1 value2 oddsratio
-    ## 1        x2  0.099  0.198  23.32353
+    ##   predictor value1 value2 oddsratio CI.low (2.5%) CI.high (97.5%)
+    ## 1        x2  0.099  0.198  23.32353      23.30424        23.34283
 
 Installation
 ------------
@@ -90,6 +96,5 @@ To see full examples, please see the examples in the respective help pages `?cal
 To Do
 -----
 
--   Add calculation of odds ratio confidence intervals
--   Implement plotting function of calculated odds ratio in GLM/GAM function?
+-   Implement some kind of plotting of calculated odds ratios within the smooth functions?
 -   Add references for odds ratio calculation?

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-[![Build Status](https://travis-ci.org/pat-s/oddsratio.svg?branch=master)](https://travis-ci.org/pat-s/oddsratio) [![CRAN\_Status\_Badge](http://www.r-pkg.org/badges/version/oddsratio)](http://cran.r-project.org/package=oddsratio) [![Downloads](http://cranlogs.r-pkg.org/badges/oddsratio?color=brightgreen)](http://www.r-pkg.org/pkg/oddsratio)
+[![Build Status](https://travis-ci.org/pat-s/oddsratio.svg?branch=master)](https://travis-ci.org/pat-s/oddsratio) [![CRAN\_Status\_Badge](http://www.r-pkg.org/badges/version/oddsratio)](http://cran.r-project.org/package=oddsratio) [![Rdoc](http://www.rdocumentation.org/badges/version/oddsratio)](http://www.rdocumentation.org/packages/oddsratio) [![Downloads](http://cranlogs.r-pkg.org/badges/oddsratio?color=brightgreen)](http://www.r-pkg.org/pkg/oddsratio)
 
 oddsratio
 =========

--- a/man/calc.oddsratio.gam.Rd
+++ b/man/calc.oddsratio.gam.Rd
@@ -4,7 +4,8 @@
 \alias{calc.oddsratio.gam}
 \title{Calculate Odds Ratio of Generalized Additive (Mixed) Models}
 \usage{
-calc.oddsratio.gam(data, model, pred, values, percentage, slice = FALSE)
+calc.oddsratio.gam(data, model, pred, values, percentage, slice = FALSE,
+  CI = NULL)
 }
 \arguments{
 \item{data}{The data used for model fitting.}
@@ -27,9 +28,13 @@ Only needed if \code{slice = TRUE}.}
 \item{slice}{Logical. \code{Default = FALSE}. Whether to calculate 
 odds ratios for fixed increment steps over the whole predictor distribution. 
 See \code{percentage} for setting the increment values.}
+
+\item{CI}{numeric. Currently fixed to 95\% confidence interval (2.5\% - 97.5\%) as it is 
+calculated manually. The reasons is that \code{\link[stats]{confint}} does not work 
+with \code{gam} outputs.}
 }
 \value{
-A data frame with (up to) six columns. \code{perc1} and \code{perc1}
+A data frame with (up to) eight columns. \code{perc1} and \code{perc2}
 are only returned if \code{slice = TRUE}:
 \item{predictor}{Predictor name}
 \item{value1}{First value of odds ratio calculation}
@@ -37,6 +42,8 @@ are only returned if \code{slice = TRUE}:
 \item{perc1}{Percentage value of \code{value1}}
 \item{perc2}{Percentage value of \code{value2}}
 \item{oddsratio}{Calculated odds ratio(s)}
+\item{CI.low}{Lower \code{(2.5\%)} confident interval of odds ratio}
+\item{CI.high}{Higher \code{(97.5\%)} confident interval of odds ratio}
 }
 \description{
 This function to calculates odds ratio(s) for specific increment 

--- a/man/calc.oddsratio.glm.Rd
+++ b/man/calc.oddsratio.glm.Rd
@@ -46,6 +46,10 @@ fit.glm <- glm(admit ~ gre + gpa + rank, data = dat, family = "binomial") # fit 
 # Calculate OR for specific increment step of continuous variable
 calc.oddsratio.glm(data = dat, model = fit.glm, incr = list(gre = 380, gpa = 5))
 
+# Calculate OR and change the confidence interval level
+calc.oddsratio.glm(data = dat, model = fit.glm, 
+                   incr = list(gre = 380, gpa = 5), CI = .70)
+
 ## Example with MASS:glmmPQL()
 # load data
 library(MASS)

--- a/man/calc.oddsratio.glm.Rd
+++ b/man/calc.oddsratio.glm.Rd
@@ -4,7 +4,7 @@
 \alias{calc.oddsratio.glm}
 \title{Calculate Odds Ratio of Generalized Linear (Mixed) Models}
 \usage{
-calc.oddsratio.glm(data, model, incr)
+calc.oddsratio.glm(data, model, incr, CI = 0.95)
 }
 \arguments{
 \item{data}{The data used for model fitting.}
@@ -12,11 +12,16 @@ calc.oddsratio.glm(data, model, incr)
 \item{model}{A fitted GLM(M).}
 
 \item{incr}{List. Increment values of each predictor.}
+
+\item{CI}{numeric. Which confident interval to calculate. 
+Must be between 0 and 1. Default to 0.95}
 }
 \value{
-A data frame with three columns:
+A data frame with five columns:
 \item{predictor}{Predictor name(s)}
 \item{oddsratio}{Calculated odds ratio(s)}
+\item{CI.low}{Lower confident interval of odds ratio}
+\item{CI.high}{Higher confident interval of odds ratio}
 \item{increment}{Increment of the predictor(s)}
 }
 \description{
@@ -24,6 +29,10 @@ This function calculates odds ratio(s) for specific
     increment steps of GLMs.
 }
 \details{
+\code{CI.low} and {CI.high} are only calculted for GLM models because 
+\code{\link[MASS]{glmmPQL}} does not return confident intervals due to its penalizing
+behaviour.
+
 Currently supported functions: \code{\link[stats]{glm}}, 
 \code{\link[MASS]{glmmPQL}}
 }


### PR DESCRIPTION
- Add confident interval calculation (`calc.oddsratio.glm`, `calc.oddsratio.gam`)
- For GLM models CI level can be specified manually
- Print CI warning if model is of type `glmmPQL`

Issue: #20 
