### PR TITLE
fledge: CRAN release v2.0.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: oddsratio
 Title: Odds Ratio Calculation for GAM(M)s & GLM(M)s
-Version: 2.0.1.9001
+Version: 2.0.2
 Authors@R: 
     person("Patrick", "Schratz", , "patrick.schratz@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0748-6624"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# oddsratio 2.0.1.9001
+# oddsratio 2.0.2
 
 ## Features
 
@@ -21,11 +21,6 @@
   Update tic templates \[ci-skip\]
 
 - Merge pull request #45 from pat-s/update-tic.
-
-  Update tic templates \[ci-skip\]
-
-
-# oddsratio 2.0.1.9000
 
 - Same as previous version.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,27 +2,10 @@
 
 # oddsratio 2.0.2
 
-## Features
-
-- Account for mixed predictor specifications.
-
 ## Chore
 
+- Account for mixed predictor specifications.
 - Upkeep maintenance.
-
-## Uncategorized
-
-- Merge branch 'main' of github.com:pat-s/oddsratio.
-
-- Merge branch 'master' of github.com:pat-s/oddsratio.
-
-- Merge pull request #46 from pat-s/update-tic.
-
-  Update tic templates \[ci-skip\]
-
-- Merge pull request #45 from pat-s/update-tic.
-
-- Same as previous version.
 
 
 # oddsratio 2.0.1

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,17 +1,5 @@
-## Test environments
+oddsratio 2.0.2
 
-* local Arch Linux installation, R 3.6.0
-* ubuntu 16.04 (on travis-ci), R-devel
-* win-builder, R-devel
+## Cran Repository Policy
 
-## R CMD check results
-
-0 errors | 0 warnings | 0 notes
-
-## Reverse dependencies
-
-There are no reverse dependencies.
-
-## Downstream dependencies
-
-"There are currently no downstream dependencies for this package”
+- [x] Reviewed CRP last edited 2024-08-27.

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,13 +1,7 @@
-citHeader("To cite package 'oddsratio' in publications use:")
-citEntry(entry = "Manual",
-	title = "R package 'oddsratio': Odds ratio calculation for GAM(M)s & GLM(M)s",
-	author = personList(as.person("Patrick Schratz")),
-	year = "2017",
-	version = "1.0.2",
-	doi = "10.5281/zenodo.1095472",
-	textVersion =
-	  paste("Schratz, P. (2017):",
-		      "R package 'oddsratio': Odds ratio calculation for GAM(M)s & GLM(M)s,",
-		      "version: 1.0.2,",
-		      "doi: 10.5281/zenodo.1095472")
+bibentry(
+  bibtype  = "Manual",
+  title    = "R package 'oddsratio': Odds ratio calculation for GAM(M)s & GLM(M)s",
+  author   = "Patrick Schratz",
+  year     = "2017",
+  doi      = "10.5281/zenodo.1095472"
 )

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -35,6 +35,8 @@ bFE
 Bg
 bG
 bh
+bibentry
+bibtype
 BJ
 blogdown
 blX

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -82,6 +82,7 @@ cran
 cre
 CRON
 cron
+CRP
 cT
 cTi
 cTt
@@ -846,6 +847,7 @@ uMd
 UMIIZ
 Un
 un
+Uncategorized
 Uo
 uQ
 uR


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2025-04-07, problems found: https://cran.r-project.org/web/checks/check_results_oddsratio.html
- [x] NOTE: r-devel-linux-x86_64-debian-clang, r-devel-linux-x86_64-debian-gcc, r-devel-windows-x86_64, r-patched-linux-x86_64
     Found the following Rd file(s) with Rd \link{} targets missing package
     anchors:
     insert_or.Rd: ggplot2
     Please provide package anchors for all Rd \link{} targets not in the
     package itself and the base packages.

Check results at: https://cran.r-project.org/web/checks/check_results_oddsratio.html

## Action items

- [x] Review PR
- [x] Await successful CI/CD run
- [x] Run `fledge::release()`
- [x] When the package is accepted on CRAN, run `fledge::post_release()`